### PR TITLE
fix: use new serverless-offline hook

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ class ServerlessOfflineDotEnv {
     this.encoding = options['dotenv-encoding'] || 'utf-8';
 
     this.hooks = {
-      'before:offline:start': this.run.bind(this),
+      'before:offline:start:init': this.run.bind(this),
     };
 
   }


### PR DESCRIPTION
It seems like serverless-offline has changed the hooks and `before:offline:start` does not work anymore with serverless-offline v6.8.0.

Changing it to `before:offline:start:init` fixes the problem.

Thanks for this plugin!