### PR TITLE
fix: allow serverless-offline newer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline-dotenv",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Override environment variables when working locally with Serverless Offline.",
   "author": "Adam Pancutt <adam@pancutt.com>",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "jest": "26"
   },
   "peerDependencies": {
-    "serverless-offline": "3"
+    "serverless-offline": "> 3"
   },
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
Currently we can't install this plugin on newer serverless versions.

This PR changes that, since the plugin is fully compatible with serverless 7.0